### PR TITLE
Added the prefixes to the roles

### DIFF
--- a/adventuregame/clemgame.json
+++ b/adventuregame/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["2.0"],
   "regression": "large",
-  "roles": ["Adventurer"]
+  "roles": [{"name": "Adventurer", "prefix": ">"}]
 }

--- a/codenames/clemgame.json
+++ b/codenames/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["2.0"],
   "regression": "large",
-  "roles": ["Cluegiver", "Guesser"]
+  "roles": [{"name": "Cluegiver", "prefix": ["CLUE:", "TARGETS:"]}, {"name": "Guesser", "prefix": "GUESS:"}]
 }

--- a/guesswhat/clemgame.json
+++ b/guesswhat/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["2.0"],
   "regression": "large",
-  "roles": ["Guesser", "Answerer"]
+  "roles": [{"name": "Guesser", "prefix": ["QUESTION:", "GUESS:"]}, {"name": "Answerer", "prefix": "ANSWER:"}]
 }

--- a/imagegame/clemgame.json
+++ b/imagegame/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["0.9", "1.0", "1.5", "2.0"],
   "regression": "small",
-  "roles": ["Instruction Giver", "Instruction Follower"]
+  "roles": [{"name": "Instruction Giver", "prefix": "Command:"}, {"name": "Instruction Follower", "prefix": ""}]
 }

--- a/matchit_ascii/clemgame.json
+++ b/matchit_ascii/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["2.0"],
   "regression": "large",
-  "roles": ["Player A", "Player B"]
+  "roles": [{"name": "Player A", "prefix": ["DESCRIPTION:", "QUESTION:", "ANSWER:", "DECISION:"]}, {"name": "Player B", "prefix": ["DESCRIPTION:", "QUESTION:", "ANSWER:", "DECISION:"]}]
 }

--- a/privateshared/clemgame.json
+++ b/privateshared/clemgame.json
@@ -7,5 +7,6 @@
   "languages": ["en"],
   "benchmark": ["0.9", "1.0", "1.5", "2.0"],
   "regression": "small",
-  "roles": ["Questioner", "Answerer"]
+  "roles": [{"name": "Questioner", "prefix": ""}, {"name": "Answerer", "prefix": ["ASIDE:", "ANSWER:"]}]
+
 }

--- a/referencegame/clemgame.json
+++ b/referencegame/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["0.9", "1.0", "1.5", "2.0"],
   "regression": "large",
-  "roles": ["Instruction Giver", "Instruction Follower"]
+  "roles": [{"name": "Instruction Giver", "prefix": "Expression:"}, {"name": "Instruction Follower", "prefix": "Answer:"}]
 }

--- a/taboo/clemgame.json
+++ b/taboo/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["0.9", "1.0", "1.5", "2.0"],
   "regression": "small",
-  "roles": ["Describer", "Guesser"]
+  "roles": [{"name": "Describer", "prefix": "CLUE:"}, {"name": "Guesser", "prefix": "GUESS:"}]
 }

--- a/textmapworld/textmapworld_main/clemgame.json
+++ b/textmapworld/textmapworld_main/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["2.0"],
   "regression": "large",
-  "roles": ["Describer"]
+  "roles": [{"name": "Guesser", "prefix": "GO:"}]
 }

--- a/textmapworld/textmapworld_specificroom/clemgame.json
+++ b/textmapworld/textmapworld_specificroom/clemgame.json
@@ -7,5 +7,5 @@
   "languages": ["en"],
   "benchmark": ["2.0"],
   "regression": "large",
-  "roles": ["Describer"]
+  "roles": [{"name": "Guesser", "prefix": "GO:"}]
 }

--- a/wordle/clemgame.json
+++ b/wordle/clemgame.json
@@ -8,7 +8,7 @@
     "languages": ["en"],
     "benchmark": ["2.0"],
     "regression": "small",
-    "roles": ["Guesser"]
+    "roles": [{"name": "Guesser", "prefix": ["explanation:", "guess:"]}]
   },
   {
     "game_name": "wordle_withclue",
@@ -20,7 +20,7 @@
     "languages": ["en"],
     "benchmark": ["2.0"],
     "regression": "large",
-    "roles": ["Guesser", "Clue Giver"]
+    "roles": [{"name": "Guesser", "prefix": ["explanation:", "guess:"]}]
   },
   {
     "game_name": "wordle_withcritic",
@@ -32,6 +32,6 @@
     "languages": ["en"],
     "benchmark": ["2.0"],
     "regression": "large",
-    "roles": ["Guesser", "Clue Giver"]
+    "roles": [{"name": "Guesser", "prefix": ["explanation:", "guess:"]}, {"name": "Clue Giver", "prefix": ["explanation:", "agreement:"]}]
   }
 ]


### PR DESCRIPTION
Added the prefixes to the roles. For example: codenames -> "roles": [{"name": "Cluegiver", "prefix": ["CLUE:", "TARGETS:"]}, {"name": "Guesser", "prefix": "GUESS:"}]
Exception: textmapworld_graphreasoning
Reasoning: to complicated prefix e.g.: {"action":"GO: east","graph":{"nodes":["Sunroom","Kitchen"],"edges":{"north":[("Sunroom","Kitchen")],"south":[("Kitchen","Sunroom")],"east":[],"west":[]}}}