### PR TITLE
Fix gamestate static

### DIFF
--- a/static/bbh/clemgame.json
+++ b/static/bbh/clemgame.json
@@ -5,6 +5,6 @@
   "players": 1,
   "image": "none",
   "languages": ["en"],
-  "benchmark": [],
+  "benchmark": ["static_1.0","standard_1.0"],
   "roles": ["Answerer"]
 }

--- a/static/bbh/master.py
+++ b/static/bbh/master.py
@@ -7,6 +7,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 from jinja2 import Template
@@ -24,13 +25,9 @@ class Answerer(Player):
 
 
 @dataclass
-class GameState:
+class BBHGameState:
     target: str
     initial_prompt: str
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated todo: extract possible choices for each experiment
-
 
 class BbhFewShotGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
@@ -38,7 +35,7 @@ class BbhFewShotGameMaster(DialogueGameMaster):
         initial_prompt = initial_prompt_template.render(input=instance["input"])
 
         # Setup game state (arguments in same order as above)
-        self.state = GameState(instance["target"], initial_prompt)
+        self.state = BBHGameState(instance["target"], initial_prompt)
 
         # Setup player
         self.answerer = Answerer(self.player_models[0], self.state.target)
@@ -48,9 +45,6 @@ class BbhFewShotGameMaster(DialogueGameMaster):
         self.request_counts: int = 0
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
-
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
 
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
@@ -67,9 +61,9 @@ class BbhFewShotGameMaster(DialogueGameMaster):
             self.state.failure = True
 
     def _on_after_game(self):
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)

--- a/static/bbh/master.py
+++ b/static/bbh/master.py
@@ -7,6 +7,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 from jinja2 import Template
@@ -24,13 +25,12 @@ class Answerer(Player):
 
 
 @dataclass
-class GameState:
+class BBHGameState(GameState):
     target: str
     initial_prompt: str
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated todo: extract possible choices for each experiment
 
+    def __post_init__(self):
+        super().__init__()
 
 class BbhFewShotGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
@@ -38,7 +38,7 @@ class BbhFewShotGameMaster(DialogueGameMaster):
         initial_prompt = initial_prompt_template.render(input=instance["input"])
 
         # Setup game state (arguments in same order as above)
-        self.state = GameState(instance["target"], initial_prompt)
+        self.state = BBHGameState(instance["target"], initial_prompt)
 
         # Setup player
         self.answerer = Answerer(self.player_models[0], self.state.target)
@@ -48,9 +48,6 @@ class BbhFewShotGameMaster(DialogueGameMaster):
         self.request_counts: int = 0
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
-
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
 
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
@@ -67,9 +64,9 @@ class BbhFewShotGameMaster(DialogueGameMaster):
             self.state.failure = True
 
     def _on_after_game(self):
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)

--- a/static/cladder/master.py
+++ b/static/cladder/master.py
@@ -8,6 +8,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster, ParseError
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 from clemcore.utils import string_utils
@@ -44,21 +45,21 @@ def parse_response(response: str, choices: List) -> str:
 
 
 @dataclass
-class GameState:
+class CLadderGameState(GameState):
     target: str
     initial_prompt: str
     choices: List[str]
     parsed_response: Optional[str] = None
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated
+
+    def __post_init__(self):
+        super().__init__()
 
 
 class CLadderGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
         # Setup game state (arguments in same order as above)
         initial_prompt = Template(self.experiment["initial_prompt"]).render(prompt=instance["input"])
-        self.state = GameState(instance["target"], initial_prompt, self.experiment["choices"])
+        self.state = CLadderGameState(instance["target"], initial_prompt, self.experiment["choices"])
 
         # Setup player
         self.answerer = Answerer(self.player_models[0], self.state.target, self.state.choices)
@@ -68,9 +69,6 @@ class CLadderGameMaster(DialogueGameMaster):
         self.request_counts: int = 0
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
-
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
 
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
@@ -83,7 +81,7 @@ class CLadderGameMaster(DialogueGameMaster):
         except ParseError as e:
             self.violated_request_counts += 1
             self.log_to_self("metadata", f"ParseError: {e.reason}")
-            self.state.aborted = True
+            self.state.abort()
             self.log_to_self("invalid format", "game_result = ABORT")
         return False
 
@@ -91,15 +89,15 @@ class CLadderGameMaster(DialogueGameMaster):
         self.log_to_self("target", self.state.target)
         if self.state.parsed_response.lower() == self.state.target.lower():
             self.log_to_self("correct label", "game_result = WIN")
-            self.state.success = True
+            self.state.succeed()
         else:
             self.log_to_self("wrong label", "game_result = LOSE")
-            self.state.failure = True
+            self.state.failed()
 
     def _on_after_game(self):
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)

--- a/static/cladder/master.py
+++ b/static/cladder/master.py
@@ -8,6 +8,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster, ParseError
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 from clemcore.utils import string_utils
@@ -44,21 +45,18 @@ def parse_response(response: str, choices: List) -> str:
 
 
 @dataclass
-class GameState:
+class CLadderGameState(GameState):
     target: str
     initial_prompt: str
     choices: List[str]
     parsed_response: Optional[str] = None
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated
 
 
 class CLadderGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
         # Setup game state (arguments in same order as above)
         initial_prompt = Template(self.experiment["initial_prompt"]).render(prompt=instance["input"])
-        self.state = GameState(instance["target"], initial_prompt, self.experiment["choices"])
+        self.state = CLadderGameState(instance["target"], initial_prompt, self.experiment["choices"])
 
         # Setup player
         self.answerer = Answerer(self.player_models[0], self.state.target, self.state.choices)
@@ -68,9 +66,6 @@ class CLadderGameMaster(DialogueGameMaster):
         self.request_counts: int = 0
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
-
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
 
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
@@ -83,7 +78,7 @@ class CLadderGameMaster(DialogueGameMaster):
         except ParseError as e:
             self.violated_request_counts += 1
             self.log_to_self("metadata", f"ParseError: {e.reason}")
-            self.state.aborted = True
+            self.state.abort()
             self.log_to_self("invalid format", "game_result = ABORT")
         return False
 
@@ -91,15 +86,15 @@ class CLadderGameMaster(DialogueGameMaster):
         self.log_to_self("target", self.state.target)
         if self.state.parsed_response.lower() == self.state.target.lower():
             self.log_to_self("correct label", "game_result = WIN")
-            self.state.success = True
+            self.state.succeed()
         else:
             self.log_to_self("wrong label", "game_result = LOSE")
-            self.state.failure = True
+            self.state.failed()
 
     def _on_after_game(self):
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)

--- a/static/eqbench/master.py
+++ b/static/eqbench/master.py
@@ -10,6 +10,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster, ParseError
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 
@@ -65,19 +66,19 @@ def parse_response(response: str, reference: Dict) -> Dict:
 
 
 @dataclass
-class GameState:
+class EQBenchGameState(GameState):
     target: Dict  # For EQBench, the target is a dict of emotion-score pairs
     initial_prompt: str  # For EQBench the input is the prompt (no templates)
     parsed_response: Optional[Dict] = None  # For EQBench, the response becomes a Dict after parsing
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated
+
+    def __post_init__(self):
+        super().__init__()
 
 
 class EQBenchGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
         # Setup game state (arguments in same order as above)
-        self.state = GameState(instance["target"], instance["input"])
+        self.state = EQBenchGameState(instance["target"], instance["input"])
 
         # Setup player
         self.answerer = Answerer(self.player_models[0], self.state.target)
@@ -87,9 +88,6 @@ class EQBenchGameMaster(DialogueGameMaster):
         self.request_counts: int = 0
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
-
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
 
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
@@ -102,7 +100,7 @@ class EQBenchGameMaster(DialogueGameMaster):
         except ParseError as e:
             self.violated_request_counts += 1
             self.log_to_self("metadata", f"ParseError: {e.reason}")
-            self.state.aborted = True
+            self.state.abort()
             self.log_to_self("invalid format", "game_result = ABORT")
         return False
 
@@ -110,17 +108,17 @@ class EQBenchGameMaster(DialogueGameMaster):
         self.log_to_self("target", to_response_format(self.state.target))
         if self.state.parsed_response == self.state.target:
             self.log_to_self("exact match", "game_result = WIN")
-            self.state.success = True
+            self.state.succeed()
         else:
             self.log_to_self("not exact match", "game_result = LOSE")
-            self.state.failure = True
+            self.state.failed()
 
     def _on_after_game(self):
         self.log_key(KEY_PARSED_RESPONSE, self.state.parsed_response)
 
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)

--- a/static/eqbench/master.py
+++ b/static/eqbench/master.py
@@ -10,6 +10,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster, ParseError
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 
@@ -65,19 +66,16 @@ def parse_response(response: str, reference: Dict) -> Dict:
 
 
 @dataclass
-class GameState:
+class EQBenchGameState(GameState):
     target: Dict  # For EQBench, the target is a dict of emotion-score pairs
     initial_prompt: str  # For EQBench the input is the prompt (no templates)
     parsed_response: Optional[Dict] = None  # For EQBench, the response becomes a Dict after parsing
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated
 
 
 class EQBenchGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
         # Setup game state (arguments in same order as above)
-        self.state = GameState(instance["target"], instance["input"])
+        self.state = EQBenchGameState(instance["target"], instance["input"])
 
         # Setup player
         self.answerer = Answerer(self.player_models[0], self.state.target)
@@ -87,9 +85,6 @@ class EQBenchGameMaster(DialogueGameMaster):
         self.request_counts: int = 0
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
-
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
 
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
@@ -102,7 +97,7 @@ class EQBenchGameMaster(DialogueGameMaster):
         except ParseError as e:
             self.violated_request_counts += 1
             self.log_to_self("metadata", f"ParseError: {e.reason}")
-            self.state.aborted = True
+            self.state.abort()
             self.log_to_self("invalid format", "game_result = ABORT")
         return False
 
@@ -110,17 +105,17 @@ class EQBenchGameMaster(DialogueGameMaster):
         self.log_to_self("target", to_response_format(self.state.target))
         if self.state.parsed_response == self.state.target:
             self.log_to_self("exact match", "game_result = WIN")
-            self.state.success = True
+            self.state.succeed()
         else:
             self.log_to_self("not exact match", "game_result = LOSE")
-            self.state.failure = True
+            self.state.failed()
 
     def _on_after_game(self):
         self.log_key(KEY_PARSED_RESPONSE, self.state.parsed_response)
 
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)

--- a/static/ifeval/master.py
+++ b/static/ifeval/master.py
@@ -6,6 +6,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 
@@ -23,12 +24,12 @@ class InstructionFollower(Player):
 
 
 @dataclass
-class GameState:
+class IFEvalGameState(GameState):
     target: Dict
     initial_prompt: str
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated (not applicable to IFEval)
+
+    def __post_init__(self):
+        super().__init__()
 
 
 def is_successful(response: str, targets: Dict) -> bool:
@@ -46,7 +47,7 @@ def is_successful(response: str, targets: Dict) -> bool:
 class IFEvalGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
         # Setup game state (arguments in same order as above)
-        self.state = GameState(instance["target"], instance["input"])
+        self.state = IFEvalGameState(instance["target"], instance["input"])
 
         # Setup player
         required_max_tokens = self.experiment["meta"]["generation_kwargs"]["max_gen_toks"]
@@ -66,9 +67,6 @@ class IFEvalGameMaster(DialogueGameMaster):
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
 
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
-
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
         self.parsed_request_counts += 1
@@ -78,15 +76,15 @@ class IFEvalGameMaster(DialogueGameMaster):
         self.log_to_self("target", self.state.target)
         if is_successful(parsed_response, self.state.target):
             self.log_to_self("followed all instructions", "game_result = WIN")
-            self.state.success = True
+            self.state.succeed()
         else:
             self.log_to_self("followed not all instructions", "game_result = LOSE")
-            self.state.failure = True
+            self.state.failed()
 
     def _on_after_game(self):
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)

--- a/static/mmlu_pro/master.py
+++ b/static/mmlu_pro/master.py
@@ -9,6 +9,7 @@ from clemcore.backends import Model
 from clemcore.clemgame import Player, GameBenchmark, GameMaster, ParseError
 from clemcore.clemgame.legacy.scorer import GameScorer
 from clemcore.clemgame.legacy.master import DialogueGameMaster
+from clemcore.clemgame.master import GameState, Outcome
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS, METRIC_REQUEST_COUNT, \
     METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, BENCH_SCORE
 from jinja2 import Template
@@ -46,22 +47,22 @@ def parse_response(response: str, choices: List, regex_pattern) -> str:
 
 
 @dataclass
-class GameState:
+class MMLUProGameState(GameState):
     target: str
     initial_prompt: str
     choices: List[str]
     regex_pattern: str
     parsed_response: Optional[str] = None
-    success: bool = False  # When response format is adhered to and exact match is achieved
-    failure: bool = False  # When response format is adhered to, but no exact match
-    aborted: bool = False  # When response format is violated
+
+    def __post_init__(self):
+        super().__init__()
 
 
 class MMLUProGameMaster(DialogueGameMaster):
     def _on_setup(self, **instance):
         # Setup game state (arguments in same order as above)
         initial_prompt = Template(self.experiment["initial_prompt"]).render(input=instance["input"])
-        self.state = GameState(instance["target"],
+        self.state = MMLUProGameState(instance["target"],
                                initial_prompt,
                                self.experiment["choices"],
                                self.experiment["regex_pattern"])  # pattern is case-sensitive!
@@ -75,9 +76,6 @@ class MMLUProGameMaster(DialogueGameMaster):
         self.parsed_request_counts: int = 0
         self.violated_request_counts: int = 0
 
-    def _does_game_proceed(self):
-        return not (self.state.aborted or self.state.failure or self.state.success)
-
     def _validate_player_response(self, player: Player, response: str) -> bool:
         self.request_counts += 1
         try:
@@ -89,7 +87,7 @@ class MMLUProGameMaster(DialogueGameMaster):
         except ParseError as e:
             self.violated_request_counts += 1
             self.log_to_self("metadata", f"ParseError: {e.reason}")
-            self.state.aborted = True
+            self.state.abort()
             self.log_to_self("invalid format", "game_result = ABORT")
         return False
 
@@ -97,15 +95,15 @@ class MMLUProGameMaster(DialogueGameMaster):
         self.log_to_self("target", self.state.target)
         if self.state.parsed_response == self.state.target:  # case-sensitive comparison!
             self.log_to_self("correct answer", "game_result = WIN")
-            self.state.success = True
+            self.state.succeed()
         else:
             self.log_to_self("wrong answer", "game_result = LOSE")
-            self.state.failure = True
+            self.state.failed()
 
     def _on_after_game(self):
-        self.log_key(METRIC_ABORTED, int(self.state.aborted))
-        self.log_key(METRIC_LOSE, int(self.state.failure))
-        self.log_key(METRIC_SUCCESS, int(self.state.success))
+        self.log_key(METRIC_ABORTED, int(self.state.outcome == Outcome.ABORTED))
+        self.log_key(METRIC_LOSE, int(self.state.outcome == Outcome.FAILURE))
+        self.log_key(METRIC_SUCCESS, int(self.state.outcome == Outcome.SUCCESS))
 
         self.log_key(METRIC_REQUEST_COUNT, self.request_counts)
         self.log_key(METRIC_REQUEST_COUNT_PARSED, self.parsed_request_counts)


### PR DESCRIPTION
For static benchmark the GameState was not defined correctly, so they always returned an error when trying to evaluate on them.
With this PR now they are defined using the GameState class from the clemgame.master file as the other games.